### PR TITLE
Corrected the commentRegEx

### DIFF
--- a/opy/opy.py
+++ b/opy/opy.py
@@ -229,7 +229,7 @@ Licence:
 	commentRegEx = re.compile (r'{0}{1}{2}.*?$'.format (
 		r"(?<!')",
 		r'(?<!")',
-		r'#'
+		r'  # '  # Acording to PEP8 an inline comment should start like this.
 	), re.MULTILINE)
 
 	commentPlaceholder = '_{0}_c_'.format (programName)


### PR DESCRIPTION
According to PEP8 (https://www.python.org/dev/peps/pep-0008/#inline-comments): "An inline comment is a comment on the same line as a statement. Inline comments should be separated by at least two spaces from the statement. They should start with a # and a single space.". Opy was looking only for "#" to detect inline comments which generated problems as noted in this issue https://github.com/QQuick/Opy/issues/10 as well as others. 
This proposed fix would assume the python code was written following the most basic style guide available.